### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,5 +63,5 @@ wheel = "^0.37.0"
 "zest.releaser" = "^6.22.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core=^1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,5 +63,5 @@ wheel = "^0.37.0"
 "zest.releaser" = "^6.22.0"
 
 [build-system]
-requires = ["poetry-core^1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This fixes 
```
(.venv) pip install .
(...)
error: invalid-pyproject-build-system-requires
× Can not process file:///C:/Users/dlinke/MyProg_exp040/django-directed
╰─> This package has an invalid `build-system.requires` key in pyproject.toml.
    It contains an invalid requirement: 'poetry-core^1.0.0'

note: This is an issue with the package mentioned above, not pip.
hint: See PEP 518 for the detailed specification.
```